### PR TITLE
Allow newer Openjpeg versions instead of fixed v2.1

### DIFF
--- a/amide-current/configure.ac
+++ b/amide-current/configure.ac
@@ -100,7 +100,8 @@ AM_PATH_GSL(1.1.1, FOUND_LIBGSL=yes, FOUND_LIBGSL=no)
 AC_CHECK_LIB(ecat, matrix_open, FOUND_LIBECAT=yes, FOUND_LIBECAT=no, -L/sw/lib)
 AC_CHECK_LIB(volpack, vpGetErrorString, FOUND_VOLPACK=yes, FOUND_VOLPACK=no, -lm -L/sw/lib -L/usr/local/lib)
 AM_PATH_XMEDCON(0.10.0, FOUND_XMEDCON=yes, FOUND_XMEDCON=no)
-AC_CHECK_HEADER([openjpeg-2.1/opj_config.h],[FOUND_OPENJP2=yes],[FOUND_OPENJP2=no])
+
+PKG_CHECK_MODULES(LIBOPENJP2, libopenjp2 >= 2.1.0, FOUND_OPENJP2=yes, FOUND_OPENJP2=no)
 
 PKG_CHECK_MODULES(VISTAIO, libvistaio >= 1.2.17, FOUND_VISTAIO=yes, FOUND_VISTAIO=no)
 
@@ -352,9 +353,8 @@ AC_ARG_ENABLE(
 
 if (test $enable_libopenjp2 = yes) && (test $FOUND_OPENJP2 = yes); then
 	echo "compiling with JPEG 2000 support "
-	AMIDE_LIBOPENJP2_LIBS="-lopenjp2"
-	dnl AC_SUBST(AMIDE_LIBOPENJP2_LIBS)
-        PKG_CHECK_MODULES(AMIDE_LIBOPENJP2, [libopenjp2 >= 2.1.0])
+	AC_SUBST(LIBOPENJP2_CFLAGS)
+	AC_SUBST(LIBOPENJP2_LIBS)
 	AC_DEFINE(AMIDE_LIBOPENJP2_SUPPORT, 1, Define to compile with openjp2)
 else
 	echo "compiling without JPEG 2000 support"

--- a/amide-current/src/Makefile.am
+++ b/amide-current/src/Makefile.am
@@ -30,7 +30,8 @@ AM_CFLAGS = \
 	-I/usr/local/include \
 	$(XMEDCON_CFLAGS) \
 	$(FFMPEG_CFLAGS) \
-	$(VISTAIO_CFLAGS) 
+	$(VISTAIO_CFLAGS) \
+	$(LIBOPENJP2_CFLAGS)
 
 
 
@@ -51,7 +52,7 @@ amide_LDADD = \
 	$(FFMPEG_LIBS) \
 	$(AMIDE_LIBDCMDATA_LIBS) \
 	$(VISTAIO_LIBS) \
-	$(AMIDE_LIBOPENJP2_LIBS) \
+	$(LIBOPENJP2_LIBS) \
 	$(AMIDE_LDADD_WIN32) 
 
 ## 2007.10.28, gcc 3.4.4 the below may no longer be an issue, as 

--- a/amide-current/src/dcmtk_interface.cc
+++ b/amide-current/src/dcmtk_interface.cc
@@ -53,8 +53,8 @@
 #ifdef AMIDE_LIBOPENJP2_SUPPORT
 #include <dcmtk/config/osconfig.h>   /* JPG2000 make sure OS specific configuration is included first */
 #include <dcmtk/dcmdata/dcpxitem.h>
-#include <openjpeg-2.1/opj_config.h>
-#include <openjpeg-2.1/openjpeg.h>
+#include <opj_config.h>
+#include <openjpeg.h>
 static void * j2k_to_raw(DcmDataset *pdata, AmitkDataSet const *pds);
 #endif
 


### PR DESCRIPTION
Hi Fernando

Now I am using PKG_CHECK_MODULE for proper LIBS and CLFAGS.  A bootstrap autoreconf changed lots of autotool files, but I only touched:

configure.ac
src/Makefile.am
src/dcmtk_interface.cc 

Cheers,
Erik
