### PR TITLE
fix: gtk3 in amide.spec.in template

### DIFF
--- a/etc/amide.spec.in
+++ b/etc/amide.spec.in
@@ -14,7 +14,7 @@ Requires:	gsl
 Requires:	volpack
 Requires:	ffmpeg-libs >= 0.4.9
 Requires:	dcmtk >= 3.6.0
-Requires:       gtk2 >= 2.16
+Requires:       gtk3
 Requires:	gnome-vfs2
 
 BuildRequires:  xmedcon-devel
@@ -26,7 +26,7 @@ BuildRequires:  gsl-devel
 BuildRequires:  dcmtk-devel
 BuildRequires:  perl-XML-Parser
 BuildRequires:  glib2-devel
-BuildRequires:  gtk2-devel >= 2.10
+BuildRequires:  gtk3-devel
 BuildRequires:	gnome-vfs2-devel
 
 %description 


### PR DESCRIPTION
Let the template list gtk3 dependencies, which the target file amide.spec already has.